### PR TITLE
separate to two middleware

### DIFF
--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -21,7 +21,11 @@ class BaseController extends LaravelBaseController
 
     public function __construct()
     {
-        $this->middleware('speedy.auth:' . $this->permissionName);
+        $this->middleware('speedy.role');
+
+        if ($this->permissionName) {
+            $this->middleware('speedy.auth:' . $this->permissionName);
+        }
     }
 
     /**

--- a/src/Http/Middleware/SpeedyRoleMiddleware.php
+++ b/src/Http/Middleware/SpeedyRoleMiddleware.php
@@ -15,7 +15,7 @@ class SpeedyRoleMiddleware
      * @param $permissionName
      * @return mixed
      */
-    public function handle($request, Closure $next, $permissionName)
+    public function handle($request, Closure $next)
     {
         $user = Auth::user();
 

--- a/src/Http/Middleware/SpeedyRoleMiddleware.php
+++ b/src/Http/Middleware/SpeedyRoleMiddleware.php
@@ -5,7 +5,7 @@ namespace Hanson\Speedy\Http\Middleware;
 use Closure;
 use Illuminate\Support\Facades\Auth;
 
-class SpeedyAdminMiddleware
+class SpeedyRoleMiddleware
 {
     /**
      * Handle an incoming request.
@@ -19,7 +19,7 @@ class SpeedyAdminMiddleware
     {
         $user = Auth::user();
 
-        if(!$user->hasPermission($permissionName)){
+        if(!$user->role_id){
             abort(403, trans('view.admin.public.403'));
         }
 

--- a/src/SpeedyServiceProvider.php
+++ b/src/SpeedyServiceProvider.php
@@ -8,6 +8,7 @@
 
 namespace Hanson\Speedy;
 
+use Hanson\Speedy\Http\Middleware\SpeedyRoleMiddleware;
 use Illuminate\Routing\Router;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
@@ -40,8 +41,10 @@ class SpeedyServiceProvider extends ServiceProvider
     {
         if (app()->version() >= 5.4) {
             $router->aliasMiddleware('speedy.auth', SpeedyAdminMiddleware::class);
+            $router->aliasMiddleware('speedy.role', SpeedyRoleMiddleware::class);
         } else {
             $router->middleware('speedy.auth', SpeedyAdminMiddleware::class);
+            $router->middleware('speedy.role', SpeedyRoleMiddleware::class);
         }
     }
 


### PR DESCRIPTION
分离中间件： 角色中间件、权限中间件

不设置 $permissionName 时， 只添加 角色中间件